### PR TITLE
[#3] 할인, 주문 도메인 기능 개발

### DIFF
--- a/src/main/kotlin/com/ttasjwi/core/OrderApp.kt
+++ b/src/main/kotlin/com/ttasjwi/core/OrderApp.kt
@@ -1,0 +1,18 @@
+package com.ttasjwi.core
+
+import com.ttasjwi.core.member.Grade
+import com.ttasjwi.core.member.Member
+import com.ttasjwi.core.member.MemberServiceImpl
+import com.ttasjwi.core.order.OrderServiceImpl
+
+fun main() {
+    val memberService = MemberServiceImpl()
+    val orderService = OrderServiceImpl()
+
+    val memberId = 1L
+    val member = Member(memberId, "memberA", Grade.VIP)
+    memberService.join(member)
+
+    val order = orderService.createOrder(memberId, "itemA", 10000)
+    print(order)
+}

--- a/src/main/kotlin/com/ttasjwi/core/discount/DiscountPolicy.kt
+++ b/src/main/kotlin/com/ttasjwi/core/discount/DiscountPolicy.kt
@@ -1,0 +1,18 @@
+package com.ttasjwi.core.discount
+
+import com.ttasjwi.core.member.Member
+
+/**
+ * 할인으로 차감되는 금액을 계산하는 역할
+ */
+interface DiscountPolicy {
+
+    /**
+     * 할인으로 차감되는 금액을 계산합니다.
+     * @param member 회원
+     * @param price 원가
+     * @return 할인으로 차감되는 금액(예: 할인되지 않으면 0원)
+     */
+    fun discount(member: Member, price: Int): Int
+
+}

--- a/src/main/kotlin/com/ttasjwi/core/discount/FixDiscountPolicy.kt
+++ b/src/main/kotlin/com/ttasjwi/core/discount/FixDiscountPolicy.kt
@@ -1,0 +1,18 @@
+package com.ttasjwi.core.discount
+
+import com.ttasjwi.core.member.Grade
+import com.ttasjwi.core.member.Member
+
+class FixDiscountPolicy : DiscountPolicy {
+
+    companion object {
+        private const val DISCOUNT_FIX_AMOUNT = 1000 // 1000원 할인
+    }
+
+    override fun discount(member: Member, price: Int): Int =
+        if (member.grade === Grade.VIP)
+            DISCOUNT_FIX_AMOUNT // VIP이면 고정 할인 적용
+        else
+            0 // VIP 아니면 할인 대상 아님
+
+}

--- a/src/main/kotlin/com/ttasjwi/core/order/Order.kt
+++ b/src/main/kotlin/com/ttasjwi/core/order/Order.kt
@@ -1,0 +1,12 @@
+package com.ttasjwi.core.order
+
+data class Order(
+    val memberId: Long,
+    val itemName: String,
+    val itemPrice: Int,
+    val discountPrice: Int) {
+
+    fun calculatePrice(): Int =
+        itemPrice - discountPrice
+
+}

--- a/src/main/kotlin/com/ttasjwi/core/order/OrderService.kt
+++ b/src/main/kotlin/com/ttasjwi/core/order/OrderService.kt
@@ -1,0 +1,6 @@
+package com.ttasjwi.core.order
+
+interface OrderService {
+
+    fun createOrder(memberId: Long, itemName: String, itemPrice: Int): Order
+}

--- a/src/main/kotlin/com/ttasjwi/core/order/OrderServiceImpl.kt
+++ b/src/main/kotlin/com/ttasjwi/core/order/OrderServiceImpl.kt
@@ -1,0 +1,27 @@
+package com.ttasjwi.core.order
+
+import com.ttasjwi.core.discount.FixDiscountPolicy
+import com.ttasjwi.core.member.MemoryMemberRepository
+
+class OrderServiceImpl : OrderService {
+
+    private val memberRepository = MemoryMemberRepository()
+    private val discountPolicy = FixDiscountPolicy()
+
+    override fun createOrder(memberId: Long, itemName: String, itemPrice: Int): Order {
+        // 회원 조회
+        val member = findMember(memberId)
+
+        // 할인금액 계산
+        val discountPrice = discountPolicy.discount(member, itemPrice)
+
+        // 주문 생성
+        return Order(memberId, itemName, itemPrice, discountPrice)
+    }
+
+    private fun findMember(memberId: Long) =
+        memberRepository.findById(memberId)
+                    ?: throw NoSuchElementException("일치하는 식별자($memberId) 의 회원 조회 실패")
+
+
+}

--- a/src/test/kotlin/com/ttasjwi/core/order/OrderServiceTest.kt
+++ b/src/test/kotlin/com/ttasjwi/core/order/OrderServiceTest.kt
@@ -1,0 +1,24 @@
+package com.ttasjwi.core.order
+
+import com.ttasjwi.core.member.Grade
+import com.ttasjwi.core.member.Member
+import com.ttasjwi.core.member.MemberServiceImpl
+import org.assertj.core.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class OrderServiceTest {
+
+    private val memberService = MemberServiceImpl()
+    private val orderService = OrderServiceImpl()
+
+    @Test
+    fun createOrder() {
+        val memberId = 1L
+        val member = Member(memberId, "memberA", Grade.VIP)
+        memberService.join(member)
+
+        val order = orderService.createOrder(memberId, "itemA", 10000)
+        assertThat(order.discountPrice).isEqualTo(1000)
+        assertThat(order.calculatePrice()).isEqualTo(9000)
+    }
+}


### PR DESCRIPTION
# 요구사항
- 회원은 상품을 주문할 수 있다.
- 회원 등급에 따라 할인 정책을 적용할 수 있다.
- 할인 정책은 모든 VIP는 1000원을 할인하는 고정 금액 할인을 적용해달라. (나중에 변경될 수 있다.)
- 할인 정책은 변경 가능성이 높다. 회사의 기본 할인 정책을 앚기 정하지 못 했고, 오픈 직전까지 고민을 미루고 싶다. 최악의 경우 할인을 적용하지 않을 수도 있다. (미확정)

# 설계
![image](https://github.com/ttasjwi/spring-hello-core/assets/88282356/6e6db913-6ce9-4ae8-b8a5-684f8c013dc6)
1. 주문 생성 요청: 클라이언트는 주문 서비스에 주문 생성을 요청한다.
2. 회원 조회: 할인을 위해서는 회원 등급이 필요하다. 그래서 주문 서비스는 회원 저장소에서 회원을 조회한다.
3. 할인 적용: 주문 서비스는 회원 등급에 따른 할인 여부를 할인 정책에 위임한다.
4. 주문 결과 반환: 주문 서비스는 할인 결과를 포함한 주문 결과를 반환한다.